### PR TITLE
Update builtin_in_metric#extract to make sure the typecast is called …

### DIFF
--- a/lib/martyr/schema/metrics/built_in_metric.rb
+++ b/lib/martyr/schema/metrics/built_in_metric.rb
@@ -38,7 +38,7 @@ module Martyr
       end
 
       def extract(fact)
-        raw_fact_value = fact.raw.fetch(fact_alias.to_s)
+        raw_fact_value = fact.raw.fetch(fact_alias.to_s).to_s
         case typecast
         when NilClass
           raw_fact_value.to_i


### PR DESCRIPTION
…on a string

This fixes bugs where ActiveRecord was able to cast a DB timestamp into a Ruby Time object. It was not able to do so in Rails < 6